### PR TITLE
fix extsize opt validation

### DIFF
--- a/MACS2/OptValidator.py
+++ b/MACS2/OptValidator.py
@@ -95,7 +95,7 @@ def opt_validate ( options ):
     #    options.extsize = 2 * options.shiftsize
     #else:                               # if --shiftsize is not set
     #    options.shiftsize = options.extsize / 2
-    if options.extsize <= 1 :
+    if options.extsize < 1 :
         logging.error("--extsize must >= 1!")
         sys.exit(1)
 


### PR DESCRIPTION
If extsize can in fact have a value of 1 (ie., >= 1 as reported in the error msg), then the option validation is incorrect.
