### PR TITLE
accurate python version reporting in setup for python 3.10+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ tests_requires = [ 'pytest' ]
 
 
 def main():
-    if float(sys.version[:3])<3.6:
+    if sys.version_info < (3,6):
         sys.stderr.write("CRITICAL: Python version must >= 3.6!\n")
         sys.exit(1)
 


### PR DESCRIPTION
version string parsing and conversion to float for python version checking fails starting with python 3.10, remediated with a slightly different check (but same dependencies) 