### PR TITLE
Fix: typo in setup.py causing an error when installing v2.2.7.1 by pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from distutils.version import LooseVersion
 import subprocess
 
 numpy_requires = '>=1.17'
-install_requires = [f"numpy>={numpy_requires}",]
+install_requires = [f"numpy{numpy_requires}",]
 
 def main():
     if float(sys.version[:3])<3.6:


### PR DESCRIPTION
Fixed a typo in setup.py which causes an error when installing MACS v2.2.7.1 with pip. Related to issue #541 .