### PR TITLE
Fixed build failing due to cython 3 being released

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires=['pip', 'setuptools>=41.2', 'numpy>=1.17', 'cython>=0.29.24', 'wheel' ]
+requires=['pip', 'setuptools>=41.2', 'numpy>=1.17', 'cython>=0.29.24,<3.0', 'wheel' ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.17
-cython>=0.29.24
+cython>=0.29.24,<3.0
 pytest>=4.6
 pytest-cov>=2.8
 codecov>=2.0


### PR DESCRIPTION
Due to cython 3 officially being release on Pypi on July 17th, 2023, cython>=0.29.24 was causing the build to use cython 3.0.0, causing build fail errors with error logs like below. This PR pins the version to be the same as before but less than 3, and build succeeds with this approach.  You may also need to make the change for MACS-3, but this should suffice for MACS 2.

```
Processing /u/mwright/MACS2
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: numpy>=1.17 in /fast/mwright/venvs/watershed/lib/python3.8/site-packages (from MACS2==2.2.8) (1.22.0)
Building wheels for collected packages: MACS2
  Building wheel for MACS2 (PEP 517) ... error
  ERROR: Command errored out with exit status 1:
   command: /fast/mwright/venvs/watershed/bin/python3 /fast/mwright/venvs/watershed/lib64/python3.8/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /tmp/tmpuavd_rnc
       cwd: /tmp/pip-req-build-y8iba4f9
  Complete output (151 lines):
  Requirement already satisfied: numpy>=1.17 in /tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages (1.24.4)
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-cpython-38
  creating build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/bdgbroadcall_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/predictd_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/pileup_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/callpeak_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/__init__.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/randsample_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/cmbreps_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/Constants.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/OutputWriter.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/bdgopt_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/diffpeak_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/filterdup_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/refinepeak_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/bdgpeakcall_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/bdgdiff_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/OptValidator.py -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/bdgcmp_cmd.py -> build/lib.linux-x86_64-cpython-38/MACS2
  creating build/lib.linux-x86_64-cpython-38/MACS2/IO
  copying MACS2/IO/__init__.py -> build/lib.linux-x86_64-cpython-38/MACS2/IO
  copying MACS2/cPosValCalculation.pxd -> build/lib.linux-x86_64-cpython-38/MACS2
  copying MACS2/khash.pxd -> build/lib.linux-x86_64-cpython-38/MACS2
  running build_ext
  Compiling MACS2/Prob.pyx because it changed.
  [1/1] Cythonizing MACS2/Prob.pyx
  building 'MACS2.Prob' extension
  creating build/temp.linux-x86_64-cpython-38
  creating build/temp.linux-x86_64-cpython-38/MACS2
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/numpy/core/include -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/Prob.c -o build/temp.linux-x86_64-cpython-38/MACS2/Prob.o -w -O3 -ffast-math -g0
  gcc -pthread -shared -Wl,-z,relro -Wl,-z,now -g -Wl,-z,relro -Wl,-z,now -g build/temp.linux-x86_64-cpython-38/MACS2/Prob.o -L/usr/lib64 -lm -o build/lib.linux-x86_64-cpython-38/MACS2/Prob.cpython-38-x86_64-linux-gnu.so
  Compiling MACS2/IO/Parser.pyx because it changed.
  [1/1] Cythonizing MACS2/IO/Parser.pyx
  building 'MACS2.IO.Parser' extension
  creating build/temp.linux-x86_64-cpython-38/MACS2/IO
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/numpy/core/include -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/IO/Parser.c -o build/temp.linux-x86_64-cpython-38/MACS2/IO/Parser.o -w -O3 -ffast-math -g0
  gcc -pthread -shared -Wl,-z,relro -Wl,-z,now -g -Wl,-z,relro -Wl,-z,now -g build/temp.linux-x86_64-cpython-38/MACS2/IO/Parser.o -L/usr/lib64 -o build/lib.linux-x86_64-cpython-38/MACS2/IO/Parser.cpython-38-x86_64-linux-gnu.so
  Compiling MACS2/Pileup.pyx because it changed.
  [1/1] Cythonizing MACS2/Pileup.pyx
  building 'MACS2.Pileup' extension
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/numpy/core/include -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/Pileup.c -o build/temp.linux-x86_64-cpython-38/MACS2/Pileup.o -w -O3 -ffast-math -g0
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/numpy/core/include -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/cPosValCalculation.c -o build/temp.linux-x86_64-cpython-38/MACS2/cPosValCalculation.o -w -O3 -ffast-math -g0
  gcc -pthread -shared -Wl,-z,relro -Wl,-z,now -g -Wl,-z,relro -Wl,-z,now -g build/temp.linux-x86_64-cpython-38/MACS2/Pileup.o build/temp.linux-x86_64-cpython-38/MACS2/cPosValCalculation.o -L/usr/lib64 -o build/lib.linux-x86_64-cpython-38/MACS2/Pileup.cpython-38-x86_64-linux-gnu.so
  Compiling MACS2/PeakModel.pyx because it changed.
  [1/1] Cythonizing MACS2/PeakModel.pyx
  building 'MACS2.PeakModel' extension
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/numpy/core/include -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/PeakModel.c -o build/temp.linux-x86_64-cpython-38/MACS2/PeakModel.o -w -O3 -ffast-math -g0
  gcc -pthread -shared -Wl,-z,relro -Wl,-z,now -g -Wl,-z,relro -Wl,-z,now -g build/temp.linux-x86_64-cpython-38/MACS2/PeakModel.o -L/usr/lib64 -o build/lib.linux-x86_64-cpython-38/MACS2/PeakModel.cpython-38-x86_64-linux-gnu.so
  Compiling MACS2/PeakDetect.pyx because it changed.
  [1/1] Cythonizing MACS2/PeakDetect.pyx
  building 'MACS2.PeakDetect' extension
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/PeakDetect.c -o build/temp.linux-x86_64-cpython-38/MACS2/PeakDetect.o -w -O3 -ffast-math -g0
  gcc -pthread -shared -Wl,-z,relro -Wl,-z,now -g -Wl,-z,relro -Wl,-z,now -g build/temp.linux-x86_64-cpython-38/MACS2/PeakDetect.o -L/usr/lib64 -o build/lib.linux-x86_64-cpython-38/MACS2/PeakDetect.cpython-38-x86_64-linux-gnu.so
  Compiling MACS2/Signal.pyx because it changed.
  [1/1] Cythonizing MACS2/Signal.pyx
  building 'MACS2.Signal' extension
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/numpy/core/include -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/Signal.c -o build/temp.linux-x86_64-cpython-38/MACS2/Signal.o -w -O3 -ffast-math -g0
  gcc -pthread -shared -Wl,-z,relro -Wl,-z,now -g -Wl,-z,relro -Wl,-z,now -g build/temp.linux-x86_64-cpython-38/MACS2/Signal.o -L/usr/lib64 -o build/lib.linux-x86_64-cpython-38/MACS2/Signal.cpython-38-x86_64-linux-gnu.so
  Compiling MACS2/IO/PeakIO.pyx because it changed.
  [1/1] Cythonizing MACS2/IO/PeakIO.pyx
  building 'MACS2.IO.PeakIO' extension
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/IO/PeakIO.c -o build/temp.linux-x86_64-cpython-38/MACS2/IO/PeakIO.o -w -O3 -ffast-math -g0
  gcc -pthread -shared -Wl,-z,relro -Wl,-z,now -g -Wl,-z,relro -Wl,-z,now -g build/temp.linux-x86_64-cpython-38/MACS2/IO/PeakIO.o -L/usr/lib64 -o build/lib.linux-x86_64-cpython-38/MACS2/IO/PeakIO.cpython-38-x86_64-linux-gnu.so
  Compiling MACS2/IO/BedGraphIO.pyx because it changed.
  [1/1] Cythonizing MACS2/IO/BedGraphIO.pyx
  building 'MACS2.IO.BedGraphIO' extension
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/fast/mwright/venvs/watershed/include -I/usr/include/python3.8 -c MACS2/IO/BedGraphIO.c -o build/temp.linux-x86_64-cpython-38/MACS2/IO/BedGraphIO.o -w -O3 -ffast-math -g0
  gcc -pthread -shared -Wl,-z,relro -Wl,-z,now -g -Wl,-z,relro -Wl,-z,now -g build/temp.linux-x86_64-cpython-38/MACS2/IO/BedGraphIO.o -L/usr/lib64 -o build/lib.linux-x86_64-cpython-38/MACS2/IO/BedGraphIO.cpython-38-x86_64-linux-gnu.so
  
  Error compiling Cython file:
  ------------------------------------------------------------
  ...
      crick_right = right_sum(crick, search_start, window_size)
  
      wtd_list = np.zeros( search_end - search_start + 1, dtype="float32")
      i = 0
      for j in range(search_start, search_end+1):
          wtd_list[i] = max((2 * (watson_left * crick_right)**0.5 - watson_right - crick_left),0) # minimum score is 0
                                                                                               ^
  ------------------------------------------------------------
  
  MACS2/IO/FixWidthTrack.pyx:949:93: complex types are unordered
  Compiling MACS2/IO/FixWidthTrack.pyx because it changed.
  [1/1] Cythonizing MACS2/IO/FixWidthTrack.pyx
  Traceback (most recent call last):
    File "/fast/mwright/venvs/watershed/lib64/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 257, in <module>
      main()
    File "/fast/mwright/venvs/watershed/lib64/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 240, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/fast/mwright/venvs/watershed/lib64/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 181, in build_wheel
      return _build_backend().build_wheel(wheel_directory, config_settings,
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 416, in build_wheel
      return self._build_with_temp_dir(['bdist_wheel'], '.whl',
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 401, in _build_with_temp_dir
      self.run_setup()
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 487, in run_setup
      super(_BuildMetaLegacyBackend,
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 338, in run_setup                                                                                
      exec(code, locals())
    File "<string>", line 104, in <module>
    File "<string>", line 69, in main
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 107, in setup                                                                                      
      return distutils.core.setup(**attrs)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 185, in setup                                                                               
      return run_commands(dist)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 201, in run_commands                                                                        
      dist.run_commands()
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands                                                                        
      self.run_command(cmd)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 1234, in run_command                                                                                   
      super().run_command(command)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command                                                                         
      cmd_obj.run()
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/wheel/bdist_wheel.py", line 343, in run                                                                                          
      self.run_command("build")
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command                                                                          
      self.distribution.run_command(command)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 1234, in run_command                                                                                   
      super().run_command(command)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command                                                                         
      cmd_obj.run()
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/build.py", line 131, in run                                                                        
      self.run_command(cmd_name)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command                                                                          
      self.distribution.run_command(command)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 1234, in run_command                                                                                   
      super().run_command(command)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command                                                                         
      cmd_obj.run()
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/command/build_ext.py", line 84, in run                                                                                
      _build_ext.run(self)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/build_ext.py", line 345, in run                                                                    
      self.build_extensions()
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/build_ext.py", line 467, in build_extensions                                                       
      self._build_extensions_serial()
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/build_ext.py", line 493, in _build_extensions_serial                                               
      self.build_extension(ext)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib/python3.8/site-packages/setuptools/command/build_ext.py", line 246, in build_extension                                                                   
      _build_ext.build_extension(self, ext)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/Cython/Distutils/build_ext.py", line 122, in build_extension                                                                   
      new_ext = cythonize(
    File "/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/Cython/Build/Dependencies.py", line 1134, in cythonize                                                                         
      cythonize_one(*args)
    File "/tmp/pip-build-env-el21d7kt/overlay/lib64/python3.8/site-packages/Cython/Build/Dependencies.py", line 1301, in cythonize_one                                                                     
      raise CompileError(None, pyx_file)
  Cython.Compiler.Errors.CompileError: MACS2/IO/FixWidthTrack.pyx
  ----------------------------------------
  ERROR: Failed building wheel for MACS2
  Running setup.py clean for MACS2
Failed to build MACS2
ERROR: Could not build wheels for MACS2 which use PEP 517 and cannot be installed directly
```
Successful build logs after this change:
```
Processing /u/mwright/MACS2
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: numpy>=1.17 in /fast/mwright/venvs/watershed/lib/python3.8/site-packages (from MACS2==2.2.8) (1.22.0)
Building wheels for collected packages: MACS2
  Building wheel for MACS2 (PEP 517) ... done
  Created wheel for MACS2: filename=MACS2-2.2.8-cp38-cp38-linux_x86_64.whl size=1705746 sha256=b99ae92ce33151dca3a85f5d5f83058ad36eb30af586cf18c4de3ca639b449e4
  Stored in directory: /tmp/pip-ephem-wheel-cache-fo8dp_0s/wheels/0b/91/f1/de747309b9d976f5b7e507c1768b4795c795ca328a7e40bcad
Successfully built MACS2
Installing collected packages: MACS2
Successfully installed MACS2-2.2.8
```
