### PR TITLE
remove pip and wheel from build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires=['pip', 'setuptools>=60.0', 'numpy>=1.19', 'cykhash>=2.0,<3.0', 'Cython~=3.0', 'wheel', 'hmmlearn>=0.3']
+requires=['setuptools>=60.0', 'numpy>=1.19', 'cykhash>=2.0,<3.0', 'Cython~=3.0', 'hmmlearn>=0.3']


### PR DESCRIPTION
1. It looks like `pip` is no longer needed during build by setup.py.
2. `wheel` is not needed, as setuptools will add it when needed (see [this section](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use)), which says:

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended. The backend automatically adds wheel dependency when it is required, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).

My motivation for this change is that I am converting [nixpkgs](https://github.com/NixOS/nixpkgs) to use [`build`](https://pypa-build.readthedocs.io/en/latest/) instead of `pip` using stronger validation of build dependencies, and I'd like to skip adding `pip` as a build dependency of this project :)