### PR TITLE
macs2: remove pip and wheel from build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires=['pip>=21', 'setuptools>=41.2', 'numpy>=1.19', 'Cython~=0.29', 'wheel' ]
+requires=['setuptools>=41.2', 'numpy>=1.19', 'Cython~=0.29']


### PR DESCRIPTION
This is a backport of https://github.com/macs3-project/MACS/pull/589. `pip` is no longer needed during the build after https://github.com/macs3-project/MACS/commit/2a277526eb291940641ab99d3ea9fcdecadcde8f, and I'd like to use this patch inside of [nixpkgs](https://github.com/NixOS/nixpkgs).