### PR TITLE
Doc/macs3/jekyll equations

### DIFF
--- a/.github/workflows/build-and-test-MACS3-macos12.yml
+++ b/.github/workflows/build-and-test-MACS3-macos12.yml
@@ -7,15 +7,15 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**.md'
     branches-ignore: 
-      - 'doc/macs3/*'
+      - 'doc/macs3/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**.md'
     branches-ignore: 
-      - 'doc/macs3/*'
+      - 'doc/macs3/**'
 jobs:
   build:
     runs-on: macos-12

--- a/.github/workflows/build-and-test-MACS3-macos12.yml
+++ b/.github/workflows/build-and-test-MACS3-macos12.yml
@@ -8,12 +8,14 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/workflows/*'
+    branches-ignore: 
+      - 'doc/macs3/*'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/workflows/*'
+    branches-ignore: 
+      - 'doc/macs3/*'
 jobs:
   build:
     runs-on: macos-12

--- a/.github/workflows/build-and-test-MACS3-macos12.yml
+++ b/.github/workflows/build-and-test-MACS3-macos12.yml
@@ -8,13 +8,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/*'
+      - '.github/workflows/*'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/*'
-
+      - '.github/workflows/*'
 jobs:
   build:
     runs-on: macos-12

--- a/.github/workflows/build-and-test-MACS3-macos12.yml
+++ b/.github/workflows/build-and-test-MACS3-macos12.yml
@@ -8,14 +8,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-    branches-ignore: 
-      - 'doc/macs3/**'
+      - '.github/workflows/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-    branches-ignore: 
-      - 'doc/macs3/**'
+      - '.github/workflows/**'
+
 jobs:
   build:
     runs-on: macos-12

--- a/.github/workflows/build-and-test-MACS3-macos12.yml
+++ b/.github/workflows/build-and-test-MACS3-macos12.yml
@@ -8,11 +8,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '.github/*'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      
+      - '.github/*'
+
 jobs:
   build:
     runs-on: macos-12
@@ -32,7 +34,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-            ${{ runner.os }}-        
+            ${{ runner.os }}-
       - name: Setup venv
         run: |
           # create venv

--- a/.github/workflows/build-and-test-MACS3-non-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-non-x64.yml
@@ -8,12 +8,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/*'
+      - '.github/workflows/*'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/*'
+      - '.github/workflows/*'
 jobs:
   build_job:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-non-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-non-x64.yml
@@ -8,10 +8,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '.github/*'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '.github/*'
 jobs:
   build_job:
     runs-on: ubuntu-20.04
@@ -20,7 +22,7 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: bullseye        
+            distro: bullseye
           - arch: armv7
             distro: bullseye
           - arch: ppc64le
@@ -83,7 +85,7 @@ jobs:
             # let's make sure this file is gone...
             rm -f no-global-site-packages.txt
             
-            # upgrade pip            
+            # upgrade pip
             pip install --progress-bar off --upgrade pip
             
             # install dependencies that are not in Debian/Linux

--- a/.github/workflows/build-and-test-MACS3-non-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-non-x64.yml
@@ -7,15 +7,15 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**.md'
     branches-ignore:
-      - 'doc/macs3/*'
+      - 'doc/macs3/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**.md'
     branches-ignore:
-      - 'doc/macs3/*'
+      - 'doc/macs3/**'
 jobs:
   build_job:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-non-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-non-x64.yml
@@ -8,12 +8,14 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/workflows/*'
+    branches-ignore:
+      - 'doc/macs3/*'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/workflows/*'
+    branches-ignore:
+      - 'doc/macs3/*'
 jobs:
   build_job:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-non-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-non-x64.yml
@@ -8,14 +8,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-    branches-ignore:
-      - 'doc/macs3/**'
+      - '.github/workflows/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-    branches-ignore:
-      - 'doc/macs3/**'
+      - '.github/workflows/**'
+
 jobs:
   build_job:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -27,6 +27,8 @@ jobs:
           mkdir site_source
           cp -r docs/ site_source/
           cp *.md site_source/
+          cp _config.yml site_source/
+          cp -r _layouts/ site_source/
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Build Website

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -8,8 +8,7 @@ on:
     paths:
       - 'docs/**'
       - '**.md'
-    branches: 
-      - 'doc/macs3/**'
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -22,11 +22,17 @@ jobs:
         uses: actions/checkout@v4
         #with: # we don't need submodules for building docs
         #  submodules: 'true'
+      - name: Copy md and images over
+        run: |
+          mkdir site_source
+          cp -r docs/ site_source/
+          cp *.md site_source/
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Build Website
         uses: actions/jekyll-build-pages@v1
         with:
+          source: "./site_source"
           destination: "./site_output"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -24,7 +24,11 @@ jobs:
         #  submodules: 'true'
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - name: Build
+      - name: Build Website
         uses: actions/jekyll-build-pages@v1
+        with:
+          destination: "./site_output"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
+        with:
+          path: "./site_output"

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -7,15 +7,9 @@ on:
   push:
     paths:
       - 'docs/**'
-      - '*.md'
+      - '**.md'
     branches: 
-      - 'doc/macs3/*'
-  pull_request:
-    paths:
-      - 'docs/**'
-      - '*.md'
-    branches: 
-      - 'doc/macs3/*'
+      - 'doc/macs3/**'
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -8,10 +8,14 @@ on:
     paths:
       - 'docs/**'
       - '*.md'
+    branches: 
+      - 'doc/macs3/*'
   pull_request:
     paths:
       - 'docs/**'
       - '*.md'
+    branches: 
+      - 'doc/macs3/*'
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -25,21 +29,9 @@ jobs:
         uses: actions/checkout@v4
         #with: # we don't need submodules for building docs
         #  submodules: 'true'
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.1'
-      - name: Install github-pages
-        run: |
-          gem install github-pages
-      - name: Build the site in Jekyll
-        run: |
-          jekyll build --source docs --destination _site
-      - name: Archive HTML files
-        run: |
-          zip -r site.zip ./_site
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: jekyll-site
-          path: site.zip
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build
+        uses: actions/jekyll-build-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -29,13 +29,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-      - name: Install dependencies
+      - name: Install github-pages
         run: |
-          gem install bundler
-          bundle install
+          gem install github-pages
       - name: Build the site in Jekyll
         run: |
-          bundle exec jekyll build
+          jekyll build
       - name: Archive HTML files
         run: |
           zip -r site.zip ./_site

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -34,7 +34,7 @@ jobs:
           gem install github-pages
       - name: Build the site in Jekyll
         run: |
-          jekyll build
+          jekyll build --source docs --destination _site
       - name: Archive HTML files
         run: |
           zip -r site.zip ./_site

--- a/.github/workflows/build-and-test-MACS3-website.yml
+++ b/.github/workflows/build-and-test-MACS3-website.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: MACS3 website using Jekyll
+
+on: 
+  push:
+    paths:
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '*.md'
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy: 
+      matrix: 
+        python-version: [3.12]
+        arch: ['x64']
+    name: Build MACS3 website on x64 with Python ${{ matrix.python-version }}
+    steps:
+      - name: Checkout MACS
+        uses: actions/checkout@v4
+        #with: # we don't need submodules for building docs
+        #  submodules: 'true'
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
+      - name: Build the site in Jekyll
+        run: |
+          bundle exec jekyll build
+      - name: Archive HTML files
+        run: |
+          zip -r site.zip ./_site
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: jekyll-site
+          path: site.zip

--- a/.github/workflows/build-and-test-MACS3-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-x64.yml
@@ -8,12 +8,14 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/workflows/*'
+    branches-ignore:
+      - 'doc/macs3/*'      
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/workflows/*'
+    branches-ignore:
+      - 'doc/macs3/*'
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-x64.yml
@@ -8,14 +8,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-    branches-ignore:
-      - 'doc/macs3/**'
+      - '.github/workflows/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-    branches-ignore:
-      - 'doc/macs3/**'
+      - '.github/workflows/**'
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-x64.yml
@@ -8,12 +8,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/*'
+      - '.github/workflows/*'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      - '.github/*'
+      - '.github/workflows/*'
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-x64.yml
@@ -7,15 +7,15 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**.md'
     branches-ignore:
-      - 'doc/macs3/*'      
+      - 'doc/macs3/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**.md'
     branches-ignore:
-      - 'doc/macs3/*'
+      - 'doc/macs3/**'
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test-MACS3-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-x64.yml
@@ -8,10 +8,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '.github/*'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '.github/*'
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The following is a set of guidelines for contributing to MACS, which is hosted i
   * [Pull Requests](#pull-requests)
 
 [Styleguides](#styleguides)
-  * [Git Commit Messages](#git-commit-messages)
+  <!-- * [Git Commit Messages](#git-commit-messages) this doesnt link anywhere -->
   * [Python Styleguide](#python-styleguide)
   * [Documentation Styleguide](#documentation-styleguide)
 
@@ -38,10 +38,10 @@ This project and everyone participating in it is governed by the [Code of Conduc
 
 We have an official tutorial and a detailed FAQ compiled from the community. 
 
-* [MACS documentations](https://macs3.github.io)
-  * [MACS tutorial](https://macs3.github.io)
-  * [MACS FAQ](https://macs3.github.io)
-  * [MACS API](https://macs3.github.io)
+* [MACS documentations](https://macs3-project.github.io/MACS/)
+  * [MACS tutorial](https://macs3.github.io) <!-- change link? -->
+  * [MACS FAQ](https://macs3.github.io) <!-- change link? -->
+  * [MACS API](https://macs3.github.io) <!-- change link? -->
 
 ### MACS Slack Community
 
@@ -65,7 +65,8 @@ Before creating bug reports, please check [this list](#before-submitting-a-bug-r
 
 #### Before Submitting A Bug Report
 
-...
+* Search [previous bugs](https://github.com/macs3-project/MACS/issues) that other people have submitted. Your issue may have been addressed, someone else may have had a similar experience, or a solution may have been implemented. Consider searching for issues that are closed or are tagged with the label "Bug Report".
+* Similarly, search through the [discussion page](https://github.com/macs3-project/MACS/discussions). There may be a discussion already started about your issue.
 
 #### How Do I Submit A (Good) Bug Report?
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,5 @@
 theme: jekyll-theme-slate
+mathjax:
+  enable: true
+  combine: false
+  tags: "ams"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,8 @@
     <script>
         MathJax = {
           tex: {
-            inlineMath: [['$$', '$$'], ['\\(', '\\)']]
+            inlineMath: [['$', '$'], ['\\(', '\\)']],
+            displayMath: [['$$', '$$'], ['\\[', '\\]']]
           },
           svg: {
             fontCache: 'global'

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,maximum-scale=2">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    
+    <!-- changes to default.html from jekyll slate, including configuration for MathJax (math equations)... PD -->
+    <script>
+        MathJax = {
+          tex: {
+            inlineMath: [['$$', '$$'], ['\\(', '\\)']]
+          },
+          svg: {
+            fontCache: 'global'
+          }
+        };
+    </script>
+    <script type="text/javascript" id="MathJax-script" async
+        src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
+    </script>
+    <!-- end changes ... PD -->
+
+    {% seo %}
+    {% include head-custom.html %}
+  </head>
+
+  <body>
+
+    <!-- HEADER -->
+    <div id="header_wrap" class="outer">
+        <header class="inner">
+          {% if site.github.is_project_page %}
+            <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
+          {% endif %}
+
+          <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
+          <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+
+          {% if site.show_downloads %}
+            <section id="downloads">
+              <a class="zip_download_link" href="{{ site.github.zip_url }}">Download this project as a .zip file</a>
+              <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
+            </section>
+          {% endif %}
+        </header>
+    </div>
+
+    <!-- MAIN CONTENT -->
+    <div id="main_content_wrap" class="outer">
+      <section id="main_content" class="inner">
+        {{ content }}
+      </section>
+    </div>
+
+    <!-- FOOTER  -->
+    <div id="footer_wrap" class="outer">
+      <footer class="inner">
+        {% if site.github.is_project_page %}
+        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        {% endif %}
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs/Advanced_Step-by-step_Peak_Calling.md
+++ b/docs/Advanced_Step-by-step_Peak_Calling.md
@@ -162,7 +162,7 @@ control.
 
 The whole genome background can be calculated as
 `the_number_of_control_reads\fragment_length/genome_size`, and in our
-example, it is $`199867*254/2700000000 ~= .0188023`$. You don\'t need to
+example, it is $$199867*254/2700000000 ~= .0188023$$. You don\'t need to
 run subcommands to build a genome background track since it\'s just a
 single value.
 

--- a/docs/Advanced_Step-by-step_Peak_Calling.md
+++ b/docs/Advanced_Step-by-step_Peak_Calling.md
@@ -162,7 +162,7 @@ control.
 
 The whole genome background can be calculated as
 `the_number_of_control_reads\fragment_length/genome_size`, and in our
-example, it is $$199867*254/2700000000 ~= .0188023$$. You don\'t need to
+example, it is $199867*254/2700000000 ~= .0188023$. You don\'t need to
 run subcommands to build a genome background track since it\'s just a
 single value.
 

--- a/docs/bdgdiff.md
+++ b/docs/bdgdiff.md
@@ -33,13 +33,11 @@ decide which condition is stronger.
 The likelihood function we used while comparing two conditions: ChIP
 (enrichment) or control (chromatin bias) is:
 
-```math
-ln(LR) = x*(ln(x)-ln(y)) + y - x
-```
+$$ln(LR) = x*(ln(x)-ln(y)) + y - x$$
 
-Here $`LR`$ is the likelihood ratio, x is the signal (fragment pileup)
+Here $$LR$$ is the likelihood ratio, x is the signal (fragment pileup)
 we observed in condition 1, and y is the signal in condition
-2. And $`ln`$ is the natural logarithm.
+2. And $$ln$$ is the natural logarithm.
 
 Note: All regions on the same chromosome in the bedGraph file should
 be continuous so only bedGraph files from MACS3 are acceptable.

--- a/docs/bdgdiff.md
+++ b/docs/bdgdiff.md
@@ -35,9 +35,9 @@ The likelihood function we used while comparing two conditions: ChIP
 
 $$ln(LR) = x*(ln(x)-ln(y)) + y - x$$
 
-Here $$LR$$ is the likelihood ratio, x is the signal (fragment pileup)
+Here $LR$ is the likelihood ratio, x is the signal (fragment pileup)
 we observed in condition 1, and y is the signal in condition
-2. And $$ln$$ is the natural logarithm.
+2. And $ln$ is the natural logarithm.
 
 Note: All regions on the same chromosome in the bedGraph file should
 be continuous so only bedGraph files from MACS3 are acceptable.

--- a/docs/callvar.md
+++ b/docs/callvar.md
@@ -155,41 +155,39 @@ four types. We assume the independence of ChIP and control experiments
 so that the generalized likelihood function is the product of the
 likelihood functions of ChIP and control data:
 
-```math
-L(\omega,\phi,g_c,g_i:D)=L(\omega,g_c:D_c)L(\phi,g_i:D_i)$$
-```
-where $`D_c`$ and $`D_i`$ represent the ChIP-Seq and control (e.g.,
+$$L(\omega,\phi,g_c,g_i:D)=L(\omega,g_c:D_c)L(\phi,g_i:D_i)$$
+
+where $$D_c$$ and $$D_i$$ represent the ChIP-Seq and control (e.g.,
 genomic input) data observed at the position including base coverage
-and base qualities. The parameter $\omega$ stands for the allele ratio
+and base qualities. The parameter $$\omega$$ stands for the allele ratio
 of allele A (chosen as the more abundant or stronger allele compared
-with the others) from the ChIP-Seq data and $\phi$ represents the
-allele ratio in the control. The parameter $`g_c`$ represents the
+with the others) from the ChIP-Seq data and $$\phi$$ represents the
+allele ratio in the control. The parameter $$g_c$$ represents the
 actual number of ChIPed DNA fragments containing allele A, which could
-differ from the observed count $`r_{c,A}`$ considering that some
-observations could be due to sequencing errors. The symbol $`g_i`$
-represents the control analogously to $`g_c`$. We use $`r_c`$ to
-denote the total number of observed allele A ($`r_{c,A}`$) and allele
-B ($`r_{c,B}`$). We assume the occurrence of the allele A ($`g_c`$)
-is from a Bernoulli trial from $`r_c`$ with the allele ratio
-$\omega$. The probability of observing the ChIP-Seq data at a certain
+differ from the observed count $$r_{c,A}$$ considering that some
+observations could be due to sequencing errors. The symbol $$g_i$$
+represents the control analogously to $$g_c$$. We use $$r_c$$ to
+denote the total number of observed allele A ($$r_{c,A}$$) and allele
+B ($$r_{c,B}$$). We assume the occurrence of the allele A ($$g_c$$)
+is from a Bernoulli trial from $$r_c$$ with the allele ratio
+$$\omega$$. The probability of observing the ChIP-Seq data at a certain
 position under a given type is as follows:
 
-```math
-Pr(D_c|g_c,\omega) = Pr(D_c|g_c) =
- \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j
- g_c/r_c\right)
- ```
 
-where $`\epsilon_j`$ represents the sequencing error of the base
+$$Pr(D_c|g_c,\omega) = Pr(D_c|g_c) =
+ \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j
+ g_c/r_c\right)$$
+
+where $$\epsilon_j$$ represents the sequencing error of the base
 showing difference with reference genome in case of mismatch
 (corresponding to SNV) and insertion. In case of deletion, the
 sequencing errors from the two bases on sequenced read surrounding the
 deletion would be considered. We model the control data in the similar
 way. We assess the likelihood functions of the 4 major type using the
-following parameters: $`\omega=1,\phi=1,g_c=r_{c,0},g_i=r_{i,0}`$ for
-A/A genotype; $`\omega=0,\phi=0,g_c=0,g_i=0`$ for B/B genotype,
-$`\omega=0.5,\phi=0.5`$ and $`g_c,g_i`$ as free variables for A/B
-genotype with unbiased binding; $`\phi=0.5`$ and $`\omega,g_c,g_i`$ as
+following parameters: $$\omega=1,\phi=1,g_c=r_{c,0},g_i=r_{i,0}$$ for
+A/A genotype; $$\omega=0,\phi=0,g_c=0,g_i=0$$ for B/B genotype,
+$$\omega=0.5,\phi=0.5$$ and $$g_c,g_i$$ as free variables for A/B
+genotype with unbiased binding; $$\phi=0.5$$ and $$\omega,g_c,g_i$$ as
 free variables for A/B genotype with biased binding or allele
 usage. Next, we apply the Bayesian Information Criterion (BIC) to
 select the best type as our prediction with the minimal BIC value

--- a/docs/callvar.md
+++ b/docs/callvar.md
@@ -174,9 +174,7 @@ $\omega$. The probability of observing the ChIP-Seq data at a certain
 position under a given type is as follows:
 
 
-$$Pr(D_c|g_c,\omega) = Pr(D_c|g_c) =
- \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j
- g_c/r_c\right)$$
+$$Pr(D_c|g_c,\omega) = \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j g_c/r_c\right)$$
 
 where $\epsilon_j$ represents the sequencing error of the base
 showing difference with reference genome in case of mismatch

--- a/docs/callvar.md
+++ b/docs/callvar.md
@@ -170,8 +170,7 @@ control analogously to $g_c$. We use $r_c$ to denote the total number
 of observed allele A ($r_{c,A}$) and allele B ($r_{c,B}$). We assume
 the occurrence of the allele A ($g_c$) is from a Bernoulli trial from
 $r_c$ with the allele ratio $\omega$. The probability of observing the
-ChIP-Seq data at a certain position under a certain binding type is as
-follows:
+ChIP-Seq data at a certain position is as follows:
 
 
 $$Pr(D_c|g_c) = \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j g_c/r_c\right)$$

--- a/docs/callvar.md
+++ b/docs/callvar.md
@@ -174,7 +174,7 @@ $\omega$. The probability of observing the ChIP-Seq data at a certain
 position under a given type is as follows:
 
 
-$$Pr(D_c|g_c,\omega) = \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j g_c/r_c\right)$$
+$$Pr(D_c|g_c) = \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j g_c/r_c\right)$$
 
 where $\epsilon_j$ represents the sequencing error of the base
 showing difference with reference genome in case of mismatch

--- a/docs/callvar.md
+++ b/docs/callvar.md
@@ -157,20 +157,20 @@ likelihood functions of ChIP and control data:
 
 $$L(\omega,\phi,g_c,g_i:D)=L(\omega,g_c:D_c)L(\phi,g_i:D_i)$$
 
-where $$D_c$$ and $$D_i$$ represent the ChIP-Seq and control (e.g.,
+where $D_c$ and $D_i$ represent the ChIP-Seq and control (e.g.,
 genomic input) data observed at the position including base coverage
-and base qualities. The parameter $$\omega$$ stands for the allele ratio
+and base qualities. The parameter $\omega$ stands for the allele ratio
 of allele A (chosen as the more abundant or stronger allele compared
-with the others) from the ChIP-Seq data and $$\phi$$ represents the
-allele ratio in the control. The parameter $$g_c$$ represents the
+with the others) from the ChIP-Seq data and $\phi$ represents the
+allele ratio in the control. The parameter $g_c$ represents the
 actual number of ChIPed DNA fragments containing allele A, which could
-differ from the observed count $$r_{c,A}$$ considering that some
-observations could be due to sequencing errors. The symbol $$g_i$$
-represents the control analogously to $$g_c$$. We use $$r_c$$ to
-denote the total number of observed allele A ($$r_{c,A}$$) and allele
-B ($$r_{c,B}$$). We assume the occurrence of the allele A ($$g_c$$)
-is from a Bernoulli trial from $$r_c$$ with the allele ratio
-$$\omega$$. The probability of observing the ChIP-Seq data at a certain
+differ from the observed count $r_{c,A}$ considering that some
+observations could be due to sequencing errors. The symbol $g_i$
+represents the control analogously to $g_c$. We use $r_c$ to
+denote the total number of observed allele A ($r_{c,A}$) and allele
+B ($r_{c,B}$). We assume the occurrence of the allele A ($g_c$)
+is from a Bernoulli trial from $r_c$ with the allele ratio
+$\omega$. The probability of observing the ChIP-Seq data at a certain
 position under a given type is as follows:
 
 
@@ -178,16 +178,16 @@ $$Pr(D_c|g_c,\omega) = Pr(D_c|g_c) =
  \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j
  g_c/r_c\right)$$
 
-where $$\epsilon_j$$ represents the sequencing error of the base
+where $\epsilon_j$ represents the sequencing error of the base
 showing difference with reference genome in case of mismatch
 (corresponding to SNV) and insertion. In case of deletion, the
 sequencing errors from the two bases on sequenced read surrounding the
 deletion would be considered. We model the control data in the similar
 way. We assess the likelihood functions of the 4 major type using the
-following parameters: $$\omega=1,\phi=1,g_c=r_{c,0},g_i=r_{i,0}$$ for
-A/A genotype; $$\omega=0,\phi=0,g_c=0,g_i=0$$ for B/B genotype,
-$$\omega=0.5,\phi=0.5$$ and $$g_c,g_i$$ as free variables for A/B
-genotype with unbiased binding; $$\phi=0.5$$ and $$\omega,g_c,g_i$$ as
+following parameters: $\omega=1,\phi=1,g_c=r_{c,0},g_i=r_{i,0}$ for
+A/A genotype; $\omega=0,\phi=0,g_c=0,g_i=0$ for B/B genotype,
+$\omega=0.5,\phi=0.5$ and $g_c,g_i$ as free variables for A/B
+genotype with unbiased binding; $\phi=0.5$ and $\omega,g_c,g_i$ as
 free variables for A/B genotype with biased binding or allele
 usage. Next, we apply the Bayesian Information Criterion (BIC) to
 select the best type as our prediction with the minimal BIC value

--- a/docs/callvar.md
+++ b/docs/callvar.md
@@ -162,42 +162,41 @@ genomic input) data observed at the position including base coverage
 and base qualities. The parameter $\omega$ stands for the allele ratio
 of allele A (chosen as the more abundant or stronger allele compared
 with the others) from the ChIP-Seq data and $\phi$ represents the
-allele ratio in the control. The parameter $g_c$ represents the
-actual number of ChIPed DNA fragments containing allele A, which could
-differ from the observed count $r_{c,A}$ considering that some
-observations could be due to sequencing errors. The symbol $g_i$
-represents the control analogously to $g_c$. We use $r_c$ to
-denote the total number of observed allele A ($r_{c,A}$) and allele
-B ($r_{c,B}$). We assume the occurrence of the allele A ($g_c$)
-is from a Bernoulli trial from $r_c$ with the allele ratio
-$\omega$. The probability of observing the ChIP-Seq data at a certain
-position under a given type is as follows:
+allele ratio in the control. The parameter $g_c$ represents the actual
+number of ChIPed DNA fragments containing allele A, which could differ
+from the observed count $r_{c,A}$ considering that some observations
+could be due to sequencing errors. The symbol $g_i$ represents the
+control analogously to $g_c$. We use $r_c$ to denote the total number
+of observed allele A ($r_{c,A}$) and allele B ($r_{c,B}$). We assume
+the occurrence of the allele A ($g_c$) is from a Bernoulli trial from
+$r_c$ with the allele ratio $\omega$. The probability of observing the
+ChIP-Seq data at a certain position under a certain binding type is as
+follows:
 
 
 $$Pr(D_c|g_c) = \sum^{r_{c,A}}_{j=1}\left((1-\epsilon_j)g_c/r_c+\epsilon_j(1-g_c/r_c)\right)\sum_{j=1}^{r_{c,B}}\left((1-\epsilon_j)(1-g_c/r_c)+\epsilon_j g_c/r_c\right)$$
 
-where $\epsilon_j$ represents the sequencing error of the base
-showing difference with reference genome in case of mismatch
-(corresponding to SNV) and insertion. In case of deletion, the
-sequencing errors from the two bases on sequenced read surrounding the
-deletion would be considered. We model the control data in the similar
-way. We assess the likelihood functions of the 4 major type using the
-following parameters: $\omega=1,\phi=1,g_c=r_{c,0},g_i=r_{i,0}$ for
-A/A genotype; $\omega=0,\phi=0,g_c=0,g_i=0$ for B/B genotype,
-$\omega=0.5,\phi=0.5$ and $g_c,g_i$ as free variables for A/B
-genotype with unbiased binding; $\phi=0.5$ and $\omega,g_c,g_i$ as
-free variables for A/B genotype with biased binding or allele
-usage. Next, we apply the Bayesian Information Criterion (BIC) to
-select the best type as our prediction with the minimal BIC value
-among the 4 models. If the best type is either “A/B, noAS” or “A/B,
-AS”, we conclude that the genotype is heterozygous (A/B). We consider
-two types of data from the same assay independently: ChIP sample that
-can have biased allele usage, and control sample that won’t have
-biased allele usage. So that in case control is not available, such as
-in ATAC-Seq assay, our model can still work. Furthermore, in case a
-good quality WGS is available, it can be regarded as the control
-sample and be inserted into our calculation to further increase the
-sensitivity.
+where $\epsilon_j$ represents the sequencing error of the base showing
+difference with reference genome in case of mismatch (corresponding to
+SNV) and insertion. In case of deletion, the sequencing errors from
+the two bases on sequenced read surrounding the deletion would be
+considered. We model the control data in the similar way. We assess
+the likelihood functions of the 4 major type using the following
+parameters: $\omega=1,\phi=1,g_c=r_{c,0},g_i=r_{i,0}$ for A/A
+genotype; $\omega=0,\phi=0,g_c=0,g_i=0$ for B/B genotype,
+$\omega=0.5,\phi=0.5$ and $g_c,g_i$ as free variables for A/B genotype
+with unbiased binding; $\phi=0.5$ and $\omega,g_c,g_i$ as free
+variables for A/B genotype with biased binding or allele usage. Next,
+we apply the Bayesian Information Criterion (BIC) to select the best
+type as our prediction with the minimal BIC value among the 4
+models. If the best type is either “A/B, noAS” or “A/B, AS”, we
+conclude that the genotype is heterozygous (A/B). We consider two
+types of data from the same assay independently: ChIP sample that can
+have biased allele usage, and control sample that won’t have biased
+allele usage. So that in case control is not available, such as in
+ATAC-Seq assay, our model can still work. Furthermore, in case a good
+quality WGS is available, it can be regarded as the control sample and
+be inserted into our calculation to further increase the sensitivity.
 
 ## Customized fields in the Output VCF file
 


### PR DESCRIPTION
Added mathjax configuration and the jekyll plugin so equations are rendered correctly in markdown files and on jekyll GitHub pages. Equations should be wrapped in double $$ for jekyll to display them as expected.