### PR TITLE
Feat/macs3/output vers libs ga

### DIFF
--- a/.github/workflows/build-and-test-MACS3-macos.yml
+++ b/.github/workflows/build-and-test-MACS3-macos.yml
@@ -48,19 +48,22 @@ jobs:
       - name: Setup venv
         run: |
           # create venv
-          python -m venv macs3venv
+          python3 -m venv macs3venv
       - name: Install dependencies
         run: |
           # make sure pip is the lastest
           source macs3venv/bin/activate
-          python -m pip install --upgrade pip
-          pip install pytest
-          if [ -f requirements.txt ]; then pip install --upgrade -r requirements.txt; fi
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pytest
+          if [ -f requirements.txt ]; then python3 -m pip install --upgrade -r requirements.txt; fi
       - name: Install MACS
         run: |
           # we use pip install instead of old fashion setup.py install
           source macs3venv/bin/activate
-          pip install .
+          python3 -m pip install .
+      - name: Output versions of installed libraries
+        run: |
+          python3 -m pip freeze
       - name: Test with pytest
         run: |
           source macs3venv/bin/activate
@@ -68,7 +71,7 @@ jobs:
       - name: Build sdist
         run: |
           source macs3venv/bin/activate
-          python setup.py sdist
+          python3 setup.py sdist
       - name: Archive sdist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-and-test-MACS3-macos.yml
+++ b/.github/workflows/build-and-test-MACS3-macos.yml
@@ -63,6 +63,7 @@ jobs:
           python3 -m pip install .
       - name: Output versions of installed libraries
         run: |
+          source macs3venv/bin/activate
           python3 -m pip freeze
       - name: Test with pytest
         run: |

--- a/.github/workflows/build-and-test-MACS3-non-x64-others.yml
+++ b/.github/workflows/build-and-test-MACS3-non-x64-others.yml
@@ -38,7 +38,7 @@ jobs:
           # Create an artifacts directory
           setup: |
             chmod a+rw ${PWD}
-        
+
           # Mount the current working directory (with checked-out codes) as /MACS3 in the container
           dockerRunArgs: |
             -v "${PWD}:/MACS3"
@@ -75,11 +75,15 @@ jobs:
 
             # install dependencies
             if [ -f requirements.txt ]; then
-              pip3 install -r requirements.txt;
+              python3 -m pip install -r requirements.txt;
             fi
 
             # install MACS3
-            pip3 install .
+            python3 -m pip install .
+
+            # output versions of installed libraries
+            python3 -m pip freeze
+
             # run test
             pytest --runxfail && cd test && ./cmdlinetest macs3
 

--- a/.github/workflows/build-and-test-MACS3-non-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-non-x64.yml
@@ -84,11 +84,15 @@ jobs:
 
             # install dependencies
             if [ -f requirements.txt ]; then
-              pip3 install -r requirements.txt;
+                python3 -m pip install -r requirements.txt;
             fi
 
             # install MACS3
-            pip3 install .
+            python3 -m pip install .
+
+            # output versions of installed libraries
+            python3 -m pip freeze
+
             # run test
             pytest --runxfail && cd test && ./cmdlinetest macs3
 

--- a/.github/workflows/build-and-test-MACS3-x64.yml
+++ b/.github/workflows/build-and-test-MACS3-x64.yml
@@ -20,8 +20,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    strategy: 
-      matrix: 
+    strategy:
+      matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         arch: ['x64']
     name: Build on x64 with Python ${{ matrix.python-version }}
@@ -44,17 +44,20 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-            ${{ runner.os }}-        
+            ${{ runner.os }}-
       - name: Install dependencies
         run: |
           # make sure pip is the lastest
-          python -m pip install --upgrade pip
-          pip install pytest
-          if [ -f requirements.txt ]; then pip install --upgrade -r requirements.txt; fi
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pytest
+          if [ -f requirements.txt ]; then python3 -m pip install --upgrade -r requirements.txt; fi
       - name: Install MACS
         run: |
           # we use pip install instead of old fashion setup.py install
-          pip install .
+          python3 -m pip install .
+      - name: Output versions of installed libraries 
+        run: |
+          python3 -m pip freeze
       - name: Test with pytest
         run: |
           pytest --runxfail
@@ -63,7 +66,7 @@ jobs:
           cd ..
       - name: Build sdist
         run: |
-          python setup.py sdist
+          python3 setup.py sdist
       - name: Archive sdist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-to-gh-with-sphinx.yml
+++ b/.github/workflows/publish-to-gh-with-sphinx.yml
@@ -31,8 +31,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install sphinx myst-parser sphinx-rtd-theme # Add other dependencies you might have
+        python3 -m pip install --upgrade pip
+        python3 -m pip install sphinx myst-parser sphinx-rtd-theme # Add other dependencies you might have
 
     - name: Build Sphinx Documentation
       run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,14 +23,14 @@ jobs:
         python-version: '3.11'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install --upgrade -r requirements.txt; fi
+        python3 -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then python3 -m pip install --upgrade -r requirements.txt; fi
         # setuptools, wheel and twine are needed to upload to pypi
-        pip install setuptools wheel twine
+        python3 -m pip install setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist
-        twine upload dist/*
+        python3 setup.py sdist
+        python3 -m twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires=['setuptools>=60.0', 'numpy>=1.24.2', 'scipy>=1.11.4', 'cykhash>=2.0,<3.0', 'Cython~=3.0', 'scikit-learn>=1.2.1', 'hmmlearn>=0.3']
+requires=['setuptools>=60.0', 'numpy>=1.24.2', 'scipy>=1.11.4', 'cykhash>=2.0,<3.0', 'Cython~=3.0', 'scikit-learn>=1.2.1', 'hmmlearn==0.3.0']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Cython~=3.0
 numpy>=1.24.2
 scipy>=1.11.4
 scikit-learn>=1.2.1
-hmmlearn>=0.3
+hmmlearn==0.3.0
 cykhash>=2.0,<3.0 
 pytest>=7.0
 setuptools>=60.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ classifiers =[\
 
 install_requires = [ "numpy>=1.24.2",
                      "scipy>=1.11.4",
-                     "hmmlearn>=0.3",
+                     "hmmlearn==0.3.0",
                      "scikit-learn>=1.2.1",
                      "cykhash>=2.0,<3.0"]
 


### PR DESCRIPTION
1. Output versions of installed python libraries in Github Actions
2. Use `python3` instead of `python`, use `python3 -m pip` instead of `pip`.
3. Fix the `hmmlearn` version to 0.3.0