### PR TITLE
Update cutoff_analysis_only return logic

### DIFF
--- a/MACS3/Commands/hmmratac_cmd.py
+++ b/MACS3/Commands/hmmratac_cmd.py
@@ -260,7 +260,7 @@ def run(args):
                                                      max_score=options.cutoff_analysis_max,
                                                      steps=options.cutoff_analysis_steps))
         # raise Exception("Cutoff analysis only.")
-        sys.exit(1)
+        sys.exit(0)
 
     #############################################
     # 3. Define training set by peak calling


### PR DESCRIPTION
Bugfix for #704 
When cutoff analysis is successfully completed, it should return a success exit code 0 rather than indicate a generic failure with exit code 1